### PR TITLE
fix: add vs runtime only in windows platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmake"
-version = "0.2.4"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 keywords = ["build-dependencies"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmake"
-version = "0.2.2"
+version = "0.2.4"
 edition = "2021"
 license = "MIT"
 keywords = ["build-dependencies"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ impl Config {
     /// Set the standard library to link against when compiling with C++
     /// support (only Android).
     /// The given library name must not contain the `lib` prefix.
-    /// 
-    /// 
+    ///
+    ///
     /// Common values:
     /// - `c++_static`
     /// - `c++_shared`
@@ -188,11 +188,11 @@ impl Config {
         let mut cmd = self.xmake_command();
         cmd.arg("build");
 
-         // In case of xmake is waiting to download something
-         cmd.arg("--yes");
-         if self.verbose {
-             cmd.arg("-v");
-         }
+        // In case of xmake is waiting to download something
+        cmd.arg("--yes");
+        if self.verbose {
+            cmd.arg("-v");
+        }
 
         if self.target.is_some() {
             cmd.arg(self.target.clone().unwrap());
@@ -269,17 +269,20 @@ impl Config {
             }
 
             if plat == "android" {
-                if let Ok(ndk) = env::var("ANDROID_NDK_HOME") { 
+                if let Ok(ndk) = env::var("ANDROID_NDK_HOME") {
                     cmd.arg(format!("--ndk={}", ndk));
                 }
                 if self.cpp_link_stdlib.is_some() {
-                    cmd.arg(format!("--ndk_cxxstl={}", self.cpp_link_stdlib.clone().unwrap())); 
-                }   
+                    cmd.arg(format!(
+                        "--ndk_cxxstl={}",
+                        self.cpp_link_stdlib.clone().unwrap()
+                    ));
+                }
                 cmd.arg(format!("--toolchain={}", "ndk"));
             }
 
             if plat == "wasm" {
-                if let Ok(emscripten) = env::var("EMSCRIPTEN_HOME") { 
+                if let Ok(emscripten) = env::var("EMSCRIPTEN_HOME") {
                     cmd.arg(format!("--emsdk={}", emscripten));
                 }
                 cmd.arg(format!("--toolchain={}", "emcc"));
@@ -307,25 +310,27 @@ impl Config {
                 cmd.arg(format!("--toolchain={}", "cross"));
             }
         } else {
-            cmd.arg(format!("--plat={}", plat)); 
+            cmd.arg(format!("--plat={}", plat));
         }
 
-        // Static CRT
-        let static_crt = self.static_crt.unwrap_or_else(|| self.get_static_crt());
-        let debug = match self.get_mode() {
-            // rusct doesn't support debug version of the CRT
-            // "debug" => "d", 
-            // "releasedbg" => "d",
-            _ => "",
-        };
+        if plat == "windows" {
+            // Static CRT
+            let static_crt = self.static_crt.unwrap_or_else(|| self.get_static_crt());
+            let debug = match self.get_mode() {
+                // rusct doesn't support debug version of the CRT
+                // "debug" => "d",
+                // "releasedbg" => "d",
+                _ => "",
+            };
 
-        let runtime = match static_crt {
-            true => format!("--vs_runtime=MT{}", debug),
-            false => format!("--vs_runtime=MD{}", debug),
-        };
-        
-        cmd.arg(runtime);
-        
+            let runtime = match static_crt {
+                true => format!("--runtimes=MT{}", debug),
+                false => format!("--runtimes=MD{}", debug),
+            };
+
+            cmd.arg(runtime);
+        }
+
         // Compilation mode: release, debug...
         let mode = self.get_mode();
         cmd.arg("-m").arg(mode);
@@ -349,9 +354,9 @@ impl Config {
         cmd.arg("install");
 
         let dst = self
-        .out_dir
-        .clone()
-        .unwrap_or_else(|| PathBuf::from(getenv_unwrap("OUT_DIR")));
+            .out_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(getenv_unwrap("OUT_DIR")));
 
         cmd.arg("-o").arg(dst.clone());
         if self.verbose {


### PR DESCRIPTION
Compiling in macOS, I got following error:
```
❯ cargo build
warning: no edition set: defaulting to the 2015 edition while the latest is 2021
   Compiling libc v0.2.162
   Compiling test-crate v0.1.0 (/Users/mitsuha/xmake-rs/test-crate)
error: failed to run custom build command for `test-crate v0.1.0 (/Users/mitsuha/xmake-rs/test-crate)`

Caused by:
  process didn't exit successfully: `/Users/mitsuha/xmake-rs/test-crate/target/debug/build/test-crate-795001f76e9a9742/build-script-build` (exit status: 101)
  --- stdout
  XMAKE = None
  running: cd "/Users/mitsuha/xmake-rs/test-crate/libdouble" && XMAKE_PROJECT_DIR="/Users/mitsuha/xmake-rs/test-crate/libdouble" "xmake" "config" "--yes" "--buildir=/Users/mitsuha/xmake-rs/test-crate/target/debug/build/test-crate-1e9e77464ad9496b/out" "--plat=macosx" "--vs_runtime=MD" "-m" "debug"
  xmake v2.9.6+20241030, A cross-platform build utility based on Lua
  Copyright (C) 2015-present Ruki Wang, tboox.org, xmake.io
                           _
      __  ___ __  __  __ _| | ______
      \ \/ / |  \/  |/ _  | |/ / __ \
       >  <  | \__/ | /_| |   <  ___/
      /_/\_\_|_|  |_|\__ \|_|\_\____|
                           by ruki, xmake.io
      
      👉  Manual: https://xmake.io/#/getting_started
      🙏  Donate: https://xmake.io/#/sponsor
      

  Usage: $xmake config|f [options] [target]

  Configure the project.
  
  Common options:
      -q, --quiet                                              Quiet operation.
      -y, --yes                                                Input yes by default if need user confirm.
          --confirm=CONFIRM                                    Input the given result if need user confirm.
                                                                   - yes
                                                                   - no
                                                                   - def
      -v, --verbose                                            Print lots of verbose information for users.
          --root                                               Allow to run xmake as root.
      -D, --diagnosis                                          Print lots of diagnosis information (backtrace, check info ..) only for developers.
                                                               And we can append -v to get more whole information.
                                                                   e.g. $ xmake -vD
      -h, --help                                               Print this help message and exit.
  
      -F FILE, --file=FILE                                     Read a given xmake.lua file.
      -P PROJECT, --project=PROJECT                            Change to the given project directory.
                                                               Search priority:
                                                                   1. The Given Command Argument
                                                                   2. The Envirnoment Variable: XMAKE_PROJECT_DIR
                                                                   3. The Current Directory
  
  Command options (config):
      -c, --clean                                              Clean the cached user configs and detection cache.
          --check                                              Just ignore detection cache and force to check all, it will reserve the cached user configs.
          --export=EXPORT                                      Export the current configuration to the given file.
                                                                   e.g.
                                                                   - xmake f -m debug -xxx=y --export=build/config.txt
          --import=IMPORT                                      Import configs from the given file.
                                                                   e.g.
                                                                   - xmake f -import=build/config.txt
          --menu                                               Configure project with a menu-driven user interface.
  
      -p PLAT, --plat=PLAT                                     Compile for the given platform. (default: auto)
                                                                   - watchos
                                                                   - msys
                                                                   - iphoneos
                                                                   - appletvos
                                                                   - harmony
                                                                   - wasm
                                                                   - cross
                                                                   - bsd
                                                                   - haiku
                                                                   - mingw
                                                                   - macosx
                                                                   - linux
                                                                   - android
                                                                   - applexros
                                                                   - windows
                                                                   - cygwin
      -a ARCH, --arch=ARCH                                     Compile for the given architecture. (default: auto)
                                                                   - watchos: armv7k i386
                                                                   - msys: i386 x86_64
                                                                   - iphoneos: arm64 x86_64
                                                                   - appletvos: arm64 x86_64
                                                                   - harmony: armeabi-v7a arm64-v8a x86 x86_64
                                                                   - wasm: wasm32 wasm64
                                                                   - cross: i386 x86_64 arm arm64 mips mips64 riscv riscv64 loong64 s390x ppc ppc64 sh4
                                                                   - bsd: i386 x86_64
                                                                   - haiku: i386 x86_64
                                                                   - mingw: i386 x86_64 arm arm64
                                                                   - macosx: x86_64 arm64
                                                                   - linux: i386 x86_64 armv7 armv7s arm64-v8a mips mips64 mipsel mips64el loong64
                                                                   - android: armeabi armeabi-v7a arm64-v8a x86 x86_64 mips mip64
                                                                   - applexros: arm64 x86_64
                                                                   - windows: x86 x64 arm arm64 arm64ec
                                                                   - cygwin: i386 x86_64
      -m MODE, --mode=MODE                                     Compile for the given mode. (default: auto)
      -k KIND, --kind=KIND                                     Compile for the given target kind. (default: static)
                                                                   - static
                                                                   - shared
                                                                   - binary
          --host=HOST                                          Set the current host environment. (default: macosx)
          --policies=POLICIES                                  Set the project policies.
                                                                   e.g.
                                                                   - xmake f --policies=package.fetch_only
                                                                   - xmake f --policies=package.precompiled:n,package.install_only
  
  Command options (Package Configuration):
          --require=REQUIRE                                    Require all dependent packages?
                                                                   - yes
                                                                   - no
          --pkg_searchdirs=PKG_SEARCHDIRS                      The search directories of the remote package.
                                                                   e.g.
                                                                   - xmake f --pkg_searchdirs=/dir1:/dir2
  
  Command options (Cross Complation Configuration):
          --cross=CROSS                                        Set cross toolchains prefix
                                                               e.g.
                                                                   - i386-mingw32-
                                                                   - arm-linux-androideabi-
          --target_os=TARGET_OS                                Set target os only for cross-complation
          --bin=BIN                                            Set cross toolchains bin directory
                                                               e.g.
                                                                   - sdk/bin (/arm-linux-gcc ..)
          --sdk=SDK                                            Set cross SDK directory
                                                               e.g.
                                                                   - sdk/bin
                                                                   - sdk/lib
                                                                   - sdk/include
          --toolchain=TOOLCHAIN                                Set toolchain name
                                                               e.g. 
                                                                   - xmake f --toolchain=clang
                                                                   - xmake f --toolchain=[cross|llvm|sdcc ..] --sdk=/xxx
                                                                   - run `xmake show -l toolchains` to get all toolchains
          --toolchain_host=TOOLCHAIN_HOST                      Set host toolchain name, it's only for building packages on host machine.
                                                               e.g. 
                                                                   - xmake f --toolchain_host=clang
                                                                   - xmake f --toolchain_host=[cross|llvm|sdcc ..] --sdk=/xxx
                                                                   - run `xmake show -l toolchains` to get all toolchains
          --runtimes=RUNTIMES                                  Set the compiler runtime library.
                                                               e.g. 
                                                                   - xmake f --runtimes=MTd
                                                                   - xmake f --runtimes=MT,c++_static
                                                                   - MT
                                                                   - MTd
                                                                   - MD
                                                                   - MDd
                                                                   - c++_static
                                                                   - c++_shared
                                                                   - stdc++_static
                                                                   - stdc++_shared
                                                                   - gnustl_static
                                                                   - gnustl_shared
                                                                   - stlport_static
                                                                   - stlport_shared
          --as=AS                                              The Assembler
          --ar=AR                                              The Static Library Linker
          --ld=LD                                              The Linker
          --sh=SH                                              The Shared Library Linker
          --asflags=ASFLAGS                                    The Assembler Flags
          --ldflags=LDFLAGS                                    The Binary Linker Flags
          --arflags=ARFLAGS                                    The Static Library Linker Flags
          --shflags=SHFLAGS                                    The Shared Library Linker Flags
          --links=LINKS                                        The Link Libraries
          --syslinks=SYSLINKS                                  The System Link Libraries
          --linkdirs=LINKDIRS                                  The Link Search Directories
          --includedirs=INCLUDEDIRS                            The Include Search Directories
          --mm=MM                                              The Objc Compiler
          --mxx=MXX                                            The Objc++ Compiler
          --mflags=MFLAGS                                      The Objc Compiler Flags
          --mxflags=MXFLAGS                                    The Objc/c++ Compiler Flags
          --mxxflags=MXXFLAGS                                  The Objc++ Compiler Flags
          --frameworks=FRAMEWORKS                              The Frameworks
          --frameworkdirs=FRAMEWORKDIRS                        The Frameworks Search Directories
          --cu=CU                                              The Cuda Compiler
          --cu-ccbin=CU-CCBIN                                  The Cuda Host C++ Compiler
          --culd=CULD                                          The Cuda Linker
          --cuflags=CUFLAGS                                    The Cuda Compiler Flags
          --culdflags=CULDFLAGS                                The Cuda Linker Flags
          --sc=SC                                              The Swift Compiler
          --scld=SCLD                                          The Swift Linker
          --scsh=SCSH                                          The Swift Shared Library Linker
          --dc=DC                                              The Dlang Compiler
          --dcld=DCLD                                          The Dlang Linker
          --dcar=DCAR                                          The Dlang Static Library Archiver
          --dcsh=DCSH                                          The Dlang Shared Library Linker
          --nc=NC                                              The Nim Compiler
          --ncld=NCLD                                          The Nim Linker
          --ncar=NCAR                                          The Nim Static Library Archiver
          --ncsh=NCSH                                          The Nim Shared Library Linker
          --zc=ZC                                              The Zig Compiler
          --zcld=ZCLD                                          The Zig Linker
          --zcar=ZCAR                                          The Zig Static Library Archiver
          --zcsh=ZCSH                                          The Zig Shared Library Linker
          --cc=CC                                              The C Compiler
          --cpp=CPP                                            The C/C++ Preprocessor
          --ranlib=RANLIB                                      The Static Library Index Generator
          --cflags=CFLAGS                                      The C Compiler Flags
          --cxflags=CXFLAGS                                    The C/C++ compiler Flags
          --fc=FC                                              The Fortran Compiler
          --fcld=FCLD                                          The Fortran Linker
          --fcsh=FCSH                                          The Fortran Shared Library Linker
          --pc=PC                                              The Pascal Compiler
          --pcld=PCLD                                          The Pascal Linker
          --pcsh=PCSH                                          The Pascal Shared Library Linker
          --mrc=MRC                                            The Microsoft Resource Compiler
          --mrcflags=MRCFLAGS                                  The Microsoft Resource Flags
          --rc=RC                                              The Rust Compiler
          --rcld=RCLD                                          The Rust Linker
          --rcar=RCAR                                          The Rust Static Library Archiver
          --rcsh=RCSH                                          The Rust Shared Library Linker
          --cxx=CXX                                            The C++ Compiler
          --cxxflags=CXXFLAGS                                  The C++ Compiler Flags
          --go=GO                                              The Golang Compiler
          --gcld=GCLD                                          The Golang Linker
          --go-ar=GO-AR                                        The Golang Static Library Linker
  
  Command options (XCode SDK Configuration):
          --xcode=XCODE                                        The Xcode Application Directory (default: auto)
          --xcode_sdkver=XCODE_SDKVER                          The SDK Version for Xcode (default: auto)
          --xcode_bundle_identifier=XCODE_BUNDLE_IDENTIFIER    The Bundle Identifier for Xcode (default: auto)
          --xcode_codesign_identity=XCODE_CODESIGN_IDENTITY    The Codesign Identity for Xcode (default: auto)
          --xcode_mobile_provision=XCODE_MOBILE_PROVISION      The Mobile Provision for Xcode (default: auto)
          --target_minver=TARGET_MINVER                        The Target Minimal Version (default: auto)
          --appledev=APPLEDEV                                  The Apple Device Type
                                                                   - simulator
                                                                   - iphone
                                                                   - watchtv
                                                                   - appletv
  
  Command options (Emscripten Configuration):
          --emsdk=EMSDK                                        The emsdk directory
  
  Command options (MingW Configuration):
          --mingw=MINGW                                        The MingW SDK Directory
  
  Command options (Cuda SDK Configuration):
          --cuda=CUDA                                          The Cuda SDK Directory (default: auto)
  
  Command options (Qt SDK Configuration):
          --qt=QT                                              The Qt SDK Directory (default: auto)
          --qt_sdkver=QT_SDKVER                                The Qt SDK Version (default: auto)
  
  Command options (Vcpkg Configuration):
          --vcpkg=VCPKG                                        The Vcpkg Directory (default: auto)
  
  Command options (Android Configuration):
          --ndk=NDK                                            The NDK Directory
          --ndk_sdkver=NDK_SDKVER                              The SDK Version for NDK (default: auto)
          --android_sdk=ANDROID_SDK                            The Android SDK Directory
          --build_toolver=BUILD_TOOLVER                        The Build Tool Version of Android SDK
          --ndk_stdcxx=[y|n]                                   Use stdc++ library for NDK (default: y)
          --ndk_cxxstl=NDK_CXXSTL                              The stdc++ stl library for NDK, (deprecated, please use --runtimes)
                                                                   - c++_static
                                                                   - c++_shared
                                                                   - gnustl_static
                                                                   - gnustl_shared
                                                                   - stlport_shared
                                                                   - stlport_static
  
  Command options (Other Configuration):
          --debugger=DEBUGGER                                  Set debugger (default: auto)
          --ccache=[y|n]                                       Enable or disable the c/c++ compiler cache. (default: y)
          --ccachedir=CCACHEDIR                                Set the ccache directory.
          --trybuild=TRYBUILD                                  Enable try-build mode and set the third-party buildsystem tool.
                                                               e.g.
                                                                   - xmake f --trybuild=auto; xmake
                                                                   - xmake f --trybuild=autoconf -p android --ndk=xxx; xmake
                                                               
                                                               the third-party buildsystems:
                                                                   - auto
                                                                   - make
                                                                   - autoconf
                                                                   - cmake
                                                                   - scons
                                                                   - meson
                                                                   - bazel
                                                                   - ninja
                                                                   - msbuild
                                                                   - xcodebuild
                                                                   - ndkbuild
                                                                   - xrepo
          --tryconfigs=TRYCONFIGS                              Set the extra configurations of the third-party buildsystem for the try-build mode.
                                                               e.g.
                                                                   - xmake f --trybuild=autoconf --tryconfigs='--enable-shared=no'
      -o BUILDIR, --buildir=BUILDIR                            Set build directory. (default: build)
  
  error: Invalid option: --vs_runtime=MD

  --- stderr
  thread 'main' panicked at /Users/mitsuha/xmake-rs/src/lib.rs:525:5:

  command did not execute successfully, got: exit status: 255

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```