### PR TITLE
fix: windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["development-tools::build-utils"]
 [dependencies]
 cc = "1.0.72"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62.2", features = ["Win32_System_Console"] }
+
 [workspace]
 members = [
     ".",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,14 +1210,17 @@ impl XmakeCommand {
         for arg in &self.args {
             self.command.arg(arg);
         }
-        if cfg!(windows) {
+        #[cfg(windows)]
+        {
             use windows::Win32::System::Console::{GetConsoleOutputCP, SetConsoleOutputCP};
             let old_cp = unsafe { GetConsoleOutputCP() };
             unsafe {let _ = SetConsoleOutputCP(65001);}
             let ret = run(&mut self.command, "xmake", self.raw_output);
             unsafe { let _ = SetConsoleOutputCP(old_cp); }
             ret
-        }else{
+        }
+        #[cfg(not(windows))]
+        {
             run(&mut self.command, "xmake", self.raw_output)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,7 +1210,16 @@ impl XmakeCommand {
         for arg in &self.args {
             self.command.arg(arg);
         }
-        run(&mut self.command, "xmake", self.raw_output)
+        if cfg!(windows) {
+            use windows::Win32::System::Console::{GetConsoleOutputCP, SetConsoleOutputCP};
+            let old_cp = unsafe { GetConsoleOutputCP() };
+            unsafe {let _ = SetConsoleOutputCP(65001);}
+            let ret = run(&mut self.command, "xmake", self.raw_output);
+            unsafe { let _ = SetConsoleOutputCP(old_cp); }
+            ret
+        }else{
+            run(&mut self.command, "xmake", self.raw_output)
+        }
     }
 
     /// Execute a lua script, located in the src folder of this crate.
@@ -1225,16 +1234,7 @@ impl XmakeCommand {
         // Script to execute are positional argument so always last
         self.args.push(script_file.into());
         self.task("lua"); // For the task to be lua
-        if cfg!(windows) {
-            use windows::Win32::System::Console::{GetConsoleOutputCP, SetConsoleOutputCP};
-            let old_cp = unsafe { GetConsoleOutputCP() };
-            unsafe {let _ = SetConsoleOutputCP(65001);}
-            let ret = self.run();
-            unsafe { let _ = SetConsoleOutputCP(old_cp); }
-            ret
-        } else {
-            self.run()
-        }
+        self.run()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,24 +592,32 @@ impl Config {
         build_info.linkdirs.push(dst.join("bin"));
 
         let mut shared_libs = HashSet::new();
-
         for link in build_info.links() {
+            let raw_name = link.name();
+            // xmake passes some libraries with the .lib extension
+            // see https://github.com/xmake-io/xmake/issues/7708
+            let link_name =
+                if plat == "windows" && raw_name.ends_with(".lib") {
+                    &raw_name[..raw_name.len() - 4]
+                } else {
+                    raw_name
+                };
             match link.kind() {
-                LinkKind::Static => println!("cargo:rustc-link-lib=static={}", link.name()),
+                LinkKind::Static => println!("cargo:rustc-link-lib=static={}", link_name),
                 LinkKind::Dynamic => {
-                    println!("cargo:rustc-link-lib=dylib={}", link.name());
-                    shared_libs.insert(link.name());
+                    println!("cargo:rustc-link-lib=dylib={}", link_name);
+                    shared_libs.insert(link_name);
                 }
                 LinkKind::Framework if plat == "macosx" => {
-                    println!("cargo:rustc-link-lib=framework={}", link.name())
+                    println!("cargo:rustc-link-lib=framework={}", link_name)
                 }
                 // For rust, framework type is only for macosx but can be used on multiple system in xmake
                 // so fallback to the system libraries case
                 LinkKind::System | LinkKind::Framework => {
-                    println!("cargo:rustc-link-lib={}", link.name())
+                    println!("cargo:rustc-link-lib={}", link_name)
                 }
                 // Let try cargo handle the rest
-                LinkKind::Unknown => println!("cargo:rustc-link-lib={}", link.name()),
+                LinkKind::Unknown => println!("cargo:rustc-link-lib={}", link_name),
             }
         }
 
@@ -1217,8 +1225,16 @@ impl XmakeCommand {
         // Script to execute are positional argument so always last
         self.args.push(script_file.into());
         self.task("lua"); // For the task to be lua
-
-        self.run()
+        if cfg!(windows) {
+            use windows::Win32::System::Console::{GetConsoleOutputCP, SetConsoleOutputCP};
+            let old_cp = unsafe { GetConsoleOutputCP() };
+            unsafe {let _ = SetConsoleOutputCP(65001);}
+            let ret = self.run();
+            unsafe { let _ = SetConsoleOutputCP(old_cp); }
+            ret
+        } else {
+            self.run()
+        }
     }
 }
 


### PR DESCRIPTION
For the Chinese version of Windows, **when running the command `xmake lua script.lua`, the output of the `print` function is not encoded in UTF-8**.

1. I modified `build_info.lua` so that `print` outputs to a file. (improve compatibility)

2. Sometimes Xmake passes static libraries with the `.lib` extension ([xmake#7708](https://github.com/xmake-io/xmake/issues/7708)), which requires you to manually remove the extension (I updated `lib.rs` to support this behavior).